### PR TITLE
Onderhoud afspraken aanmaken

### DIFF
--- a/Project/BarrocIntens/Data/ServiceRequest.cs
+++ b/Project/BarrocIntens/Data/ServiceRequest.cs
@@ -11,7 +11,7 @@ namespace BarrocIntens.Data
         public int Id { get; set; }
         public string Description { get; set; }
         public DateTime Date_Reported { get; set; }
-        public int Status { get; set; }
+        public int Status { get; set; } //1 = UnAssigned; 2 = In Progress; 3 = Done;
         public int CustomerId { get; set; }
         public int ProductId { get; set; }
         public Customer Customer { get; set; }

--- a/Project/BarrocIntens/Data/WorkOrder.cs
+++ b/Project/BarrocIntens/Data/WorkOrder.cs
@@ -13,10 +13,10 @@ namespace BarrocIntens.Data
         public int UserId { get; set; }
         public int? ProductId { get; set; }
         public int AppointmentId { get; set; }
-        public int RequestId { get; set; }
+        public int? RequestId { get; set; }
         public User User { get; set; }
         public Product? Product { get; set; }
         public Appointment Appointment { get; set; }
-        public ServiceRequest Request { get; set; }
+        public ServiceRequest? Request { get; set; }
     }
 }

--- a/Project/BarrocIntens/Data/WorkOrder.cs
+++ b/Project/BarrocIntens/Data/WorkOrder.cs
@@ -11,11 +11,11 @@ namespace BarrocIntens.Data
         public int Id { get; set; }
         public string Description { get; set; }
         public int UserId { get; set; }
-        public int ProductId { get; set; }
+        public int? ProductId { get; set; }
         public int AppointmentId { get; set; }
         public int RequestId { get; set; }
         public User User { get; set; }
-        public Product Product { get; set; }
+        public Product? Product { get; set; }
         public Appointment Appointment { get; set; }
         public ServiceRequest Request { get; set; }
     }

--- a/Project/BarrocIntens/Onderhoud/OnderhoudAfsprakenCreatePage.xaml
+++ b/Project/BarrocIntens/Onderhoud/OnderhoudAfsprakenCreatePage.xaml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <Page
     x:Class="BarrocIntens.Onderhoud.OnderhoudAfsprakenCreatePage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
@@ -10,11 +9,43 @@
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid Background="#3e3e3e">
-        <!-- Titel bovenaan -->
         <Border HorizontalAlignment="Center" VerticalAlignment="Top" Margin="10" Background="Transparent">
             <StackPanel>
                 <TextBlock Text="Afspraken Create" Foreground="#ffffff" FontSize="40" FontWeight="Bold" HorizontalAlignment="Center" VerticalAlignment="Top" Margin="0,40,0,0"/>
             </StackPanel>
         </Border>
+
+        <Grid Background="Black" Padding="20" CornerRadius="10" HorizontalAlignment="Center" VerticalAlignment="Center" Width="700">
+            <StackPanel Spacing="20">
+                <StackPanel>
+                    <TextBlock Text="Beschrijving:" Foreground="#FDD716" FontSize="18" FontWeight="Bold"/>
+                    <TextBox x:Name="DescriptionTextBox" PlaceholderText="Vul de afspraak beschrijving in" FontSize="16" Padding="10"/>
+                </StackPanel>
+
+                <StackPanel>
+                    <TextBlock Text="Datum:" Foreground="#FDD716" FontSize="18" FontWeight="Bold"/>
+                    <DatePicker x:Name="DatePicker" FontSize="16"/>
+                </StackPanel>
+
+                <StackPanel>
+                    <TextBlock Text="Medewerker:" Foreground="#FDD716" FontSize="18" FontWeight="Bold"/>
+                    <ComboBox x:Name="UserComboBox" FontSize="16" PlaceholderText="Selecteer een medewerker"/>
+                </StackPanel>
+
+                <StackPanel>
+                    <TextBlock Text="Klant:" Foreground="#FDD716" FontSize="18" FontWeight="Bold"/>
+                    <ComboBox x:Name="CustomerComboBox" FontSize="16" PlaceholderText="Selecteer een klant"/>
+                </StackPanel>
+
+                <Border BorderBrush="#FDD716" BorderThickness="1" Padding="10" CornerRadius="5">
+                    <StackPanel>
+                        <TextBlock Text="StoringsAanvraag (optioneel):" Foreground="#FDD716" FontSize="18" FontWeight="Bold"/>
+                        <ComboBox x:Name="ServiceRequestComboBox" FontSize="16" PlaceholderText="Selecteer een StoringsAanvraag"/>
+                    </StackPanel>
+                </Border>
+
+                <Button Content="Opslaan" FontSize="20" FontWeight="Bold" Background="#FDD716" Foreground="Black" Width="200" HorizontalAlignment="Center" Click="SaveAppointmentButton_Click"/>
+            </StackPanel>
+        </Grid>
     </Grid>
 </Page>

--- a/Project/BarrocIntens/Onderhoud/OnderhoudAfsprakenCreatePage.xaml.cs
+++ b/Project/BarrocIntens/Onderhoud/OnderhoudAfsprakenCreatePage.xaml.cs
@@ -1,31 +1,121 @@
+using BarrocIntens.Data;
+using BarrocIntens.Sales;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Controls.Primitives;
-using Microsoft.UI.Xaml.Data;
-using Microsoft.UI.Xaml.Input;
-using Microsoft.UI.Xaml.Media;
 using Microsoft.UI.Xaml.Navigation;
 using System;
-using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Runtime.InteropServices.WindowsRuntime;
-using Windows.Foundation;
-using Windows.Foundation.Collections;
-
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
 
 namespace BarrocIntens.Onderhoud
 {
-	/// <summary>
-	/// An empty page that can be used on its own or navigated to within a Frame.
-	/// </summary>
 	public sealed partial class OnderhoudAfsprakenCreatePage : Page
 	{
+		private OnderhoudBaseWindow _parentWindow;
 		public OnderhoudAfsprakenCreatePage()
 		{
 			this.InitializeComponent();
+			LoadData();
+		}
+
+		protected override void OnNavigatedTo(NavigationEventArgs e)
+		{
+			base.OnNavigatedTo(e);
+
+			if(e.Parameter is OnderhoudBaseWindow parentWindow)
+			{
+				_parentWindow = parentWindow;
+			}
+		}
+
+		private void LoadData()
+		{
+			using(var db = new AppDbContext())
+			{
+				var users = db.Users
+					.Where(u => u.DepartmentId == 2)
+					.Select(u => new { u.Id, u.Name })
+					.ToList();
+				UserComboBox.ItemsSource = users;
+				UserComboBox.DisplayMemberPath = "Name";
+				UserComboBox.SelectedValuePath = "Id";
+
+				var customers = db.Customers
+					.OrderBy(c => c.Name)
+					.Select(c => new { c.Id, c.Name })
+					.ToList();
+				CustomerComboBox.ItemsSource = customers;
+				CustomerComboBox.DisplayMemberPath = "Name";
+				CustomerComboBox.SelectedValuePath = "Id";
+
+				var serviceRequests = db.ServiceRequests
+					.Where(sr => sr.Status == 1)
+					.OrderBy(sr => sr.Date_Reported)
+					.Select(sr => new
+					{
+						sr.Id,
+						DisplayText = $"{sr.Description} - {sr.FormattedDateReported}"
+					})
+					.ToList();
+				ServiceRequestComboBox.ItemsSource = serviceRequests;
+				ServiceRequestComboBox.DisplayMemberPath = "DisplayText";
+				ServiceRequestComboBox.SelectedValuePath = "Id";
+			}
+		}
+
+		private void SaveAppointmentButton_Click(object sender, RoutedEventArgs e)
+		{
+			if(string.IsNullOrWhiteSpace(DescriptionTextBox.Text) || DatePicker.SelectedDate == null ||
+				UserComboBox.SelectedValue == null || CustomerComboBox.SelectedValue == null)
+			{
+				ContentDialog errorDialog = new ContentDialog
+				{
+					Title = "Veld leeg",
+					Content = "Alle velden moeten worden ingevuld.",
+					CloseButtonText = "Ok",
+					XamlRoot = this.XamlRoot
+				};
+				errorDialog.ShowAsync();
+				return;
+			}
+
+			using(var db = new AppDbContext())
+			{
+				var appointment = new Appointment
+				{
+					Description = DescriptionTextBox.Text.Trim(),
+					Date = DatePicker.SelectedDate.Value.DateTime,
+					UserId = (int)UserComboBox.SelectedValue,
+					CustomerId = (int)CustomerComboBox.SelectedValue
+				};
+
+				db.Appointments.Add(appointment);
+				db.SaveChanges();
+
+				// If a ServiceRequest is selected, create a WorkOrder
+				if(ServiceRequestComboBox.SelectedValue != null)
+				{
+					var workOrder = new WorkOrder
+					{
+						Description = appointment.Description,
+						UserId = appointment.UserId,
+						ProductId = null,
+						AppointmentId = appointment.Id,
+						RequestId = (int)ServiceRequestComboBox.SelectedValue
+					};
+
+					db.WorkOrders.Add(workOrder);
+					db.SaveChanges();
+				}
+			}
+			_parentWindow.NavigateToPlanningPage();
+			//ContentDialog successDialog = new ContentDialog
+			//{
+			//	Title = "Succes",
+			//	Content = "Afspraak succesvol opgeslagen.",
+			//	CloseButtonText = "Ok",
+			//	XamlRoot = this.XamlRoot
+			//};
+			//successDialog.ShowAsync();
 		}
 	}
 }

--- a/Project/BarrocIntens/Onderhoud/OnderhoudAfsprakenCreatePage.xaml.cs
+++ b/Project/BarrocIntens/Onderhoud/OnderhoudAfsprakenCreatePage.xaml.cs
@@ -62,7 +62,7 @@ namespace BarrocIntens.Onderhoud
 			}
 		}
 
-		private void SaveAppointmentButton_Click(object sender, RoutedEventArgs e)
+		private async void SaveAppointmentButton_Click(object sender, RoutedEventArgs e)
 		{
 			if(string.IsNullOrWhiteSpace(DescriptionTextBox.Text) || DatePicker.SelectedDate == null ||
 				UserComboBox.SelectedValue == null || CustomerComboBox.SelectedValue == null)
@@ -94,6 +94,15 @@ namespace BarrocIntens.Onderhoud
 				// If a ServiceRequest is selected, create a WorkOrder
 				if(ServiceRequestComboBox.SelectedValue != null)
 				{
+					int serviceRequestId = (int)ServiceRequestComboBox.SelectedValue;
+
+					var serviceRequest = db.ServiceRequests.SingleOrDefault(sr => sr.Id == serviceRequestId);
+					if(serviceRequest != null)
+					{
+						serviceRequest.Status = 2; // Update the status to 2
+					}
+					db.ServiceRequests.Update(serviceRequest);
+
 					var workOrder = new WorkOrder
 					{
 						Description = appointment.Description,
@@ -107,15 +116,34 @@ namespace BarrocIntens.Onderhoud
 					db.SaveChanges();
 				}
 			}
-			_parentWindow.NavigateToPlanningPage();
-			//ContentDialog successDialog = new ContentDialog
-			//{
-			//	Title = "Succes",
-			//	Content = "Afspraak succesvol opgeslagen.",
-			//	CloseButtonText = "Ok",
-			//	XamlRoot = this.XamlRoot
-			//};
-			//successDialog.ShowAsync();
+			ContentDialog successDialog = new ContentDialog
+			{
+				Title = "Succes",
+				Content = "Afspraak succesvol opgeslagen.\nWilt u terugkeren naar de planning of nog een nieuwe afspraak maken?",
+				PrimaryButtonText = "Ga naar planning",
+				SecondaryButtonText = "Nieuwe afspraak",
+				XamlRoot = this.XamlRoot
+			};
+
+			var result = await successDialog.ShowAsync();
+
+			if(result == ContentDialogResult.Primary)
+			{
+				_parentWindow.NavigateToPlanningPage();
+			}
+			else if(result == ContentDialogResult.Secondary)
+			{
+				ResetForm();
+			}
 		}
+		private void ResetForm()
+		{
+			DescriptionTextBox.Text = string.Empty;
+			DatePicker.SelectedDate = null;
+			UserComboBox.SelectedIndex = -1;
+			CustomerComboBox.SelectedIndex = -1;
+			ServiceRequestComboBox.SelectedIndex = -1;
+		}
+
 	}
 }

--- a/Project/BarrocIntens/Onderhoud/OnderhoudBaseWindow.xaml.cs
+++ b/Project/BarrocIntens/Onderhoud/OnderhoudBaseWindow.xaml.cs
@@ -46,9 +46,10 @@ namespace BarrocIntens.Onderhoud
 			{
 
 			}
-			SetButtonVisibility();
 
 			MainFrame.Navigate(typeof(OnderhoudMainPage));
+
+			SetButtonVisibility();
 		}
 
 		private void SetButtonVisibility()
@@ -134,12 +135,20 @@ namespace BarrocIntens.Onderhoud
 
 		private void AfspraakCreateButton_Click(object sender, RoutedEventArgs e)
 		{
-
+			MainFrame.Navigate(typeof(OnderhoudAfsprakenCreatePage), this);
+			SetButtonVisibility();
 		}
 
 		private void PlanningButton_Click(object sender, RoutedEventArgs e)
 		{
+			MainFrame.Navigate(typeof(OnderhoudMainPage));
+			SetButtonVisibility();
+		}
 
+		public void NavigateToPlanningPage()
+		{
+			MainFrame.Navigate(typeof(OnderhoudMainPage));
+			SetButtonVisibility();
 		}
 	}
 }


### PR DESCRIPTION
Als afspraak word gemaakt word en de user wilt de afspraak aan een service request koppelen dan word dat via een workOrder gedaan. Bij workorder word dan de titel van afspraak tijdelijk ingevuld, er word ingevuld om welke klant het gaat, en de Id van Appointment en ServiceRequest. De productId blijft leeg (dit moet de medewerker later zelf invullen bij de workOrder). 

Ik heb bij workOrder de ProductId en ServiceRequestId leeg gelaten (als later iemand een workOrder aan wilt maken voor een check up hoeft die persoon niet een serviceRequest toevoegen).